### PR TITLE
Add Foldable and Traversable instance support, fix bugs, and add tests

### DIFF
--- a/purescript-bridge.cabal
+++ b/purescript-bridge.cabal
@@ -51,6 +51,13 @@ Test-Suite tests
   type:          exitcode-stdio-1.0
   main-is:       Spec.hs
   other-modules: TestData
+               , BuilderSpec
+               , PrimitivesSpec
+               , PrinterSpec
+               , PSTypesSpec
+               , SumTypeSpec
+               , TupleSpec
+               , TypeInfoSpec
                , RoundTripArgonautAesonGeneric.Spec
                , RoundTripArgonautAesonGeneric.Types
                , RoundTripJsonHelpers.Spec

--- a/src/Language/PureScript/Bridge.hs
+++ b/src/Language/PureScript/Bridge.hs
@@ -149,8 +149,10 @@ import           Language.PureScript.Bridge.SumType as Bridge (CustomInstance (.
                                                                customHead,
                                                                customImplementation,
                                                                equal, equal1,
+                                                               foldable,
                                                                functor,
                                                                genericShow,
+                                                               traversable,
                                                                getUsedTypes,
                                                                importsFromList,
                                                                instanceToImportLines,
@@ -298,6 +300,8 @@ bridgeSumType br (SumType t cs is) =
     bridgeInstance (ForeignObject x y) = ForeignObject x y
     bridgeInstance GenericShow = GenericShow
     bridgeInstance Functor = Functor
+    bridgeInstance Foldable = Foldable
+    bridgeInstance Traversable = Traversable
     bridgeInstance Eq = Eq
     bridgeInstance Eq1 = Eq1
     bridgeInstance Ord = Ord

--- a/src/Language/PureScript/Bridge.hs
+++ b/src/Language/PureScript/Bridge.hs
@@ -149,6 +149,7 @@ import           Language.PureScript.Bridge.SumType as Bridge (CustomInstance (.
                                                                customHead,
                                                                customImplementation,
                                                                equal, equal1,
+                                                               excludeFields,
                                                                foldable,
                                                                functor,
                                                                genericShow,

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -363,6 +363,8 @@ instances st@(SumType t dcs is) = nub $ go <$> is
                 ]
     go GenericShow = mkInstance (mkType "Show" [t]) (showConstraints usedVariables) ["show a = genericShow a"]
     go Functor = mkDerivedInstance (mkType "Functor" [toKind1 t]) (const [])
+    go Foldable = mkDerivedInstance (mkType "Foldable" [toKind1 t]) (const [])
+    go Traversable = mkDerivedInstance (mkType "Traversable" [toKind1 t]) (const [])
     go Eq = mkDerivedInstance (mkType "Eq" [t]) eqConstraints
     go Eq1 = mkDerivedInstance (mkType "Eq1" [toKind1 t]) (const [])
     go Ord = mkDerivedInstance (mkType "Ord" [t]) ordConstraints

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -250,6 +250,15 @@ getVariableFromTypeInfo ti =
         Nothing     -> Nothing
         Just (f, _) -> if isLower f then Just x else Nothing
 
+-- | Recursively collect all type variables from a TypeInfo, including those
+-- nested inside type constructors (e.g., the @a@ in @NonEmptyArray a@).
+collectVariables :: TypeInfo 'PureScript -> [Text]
+collectVariables ti =
+  let self = case T.uncons (_typeName ti) of
+        Just (f, _) | isLower f -> [_typeName ti]
+        _                       -> []
+  in self <> concatMap collectVariables (_typeParameters ti)
+
 instance Eq Doc where
   (==) a b = (show a) == (show b)
 
@@ -261,8 +270,8 @@ instances st@(SumType t dcs is) = nub $ go <$> is
     getVariablesFromDataConstructor :: DataConstructor 'PureScript -> [Text]
     getVariablesFromDataConstructor dc = case _sigValues dc of
       Nullary   -> []
-      Normal ne -> catMaybes $ NE.toList $ NE.map getVariableFromTypeInfo ne
-      Record re -> catMaybes $ NE.toList $ NE.map (getVariableFromTypeInfo . _recValue) re
+      Normal ne -> concatMap collectVariables $ NE.toList ne
+      Record re -> concatMap (collectVariables . _recValue) $ NE.toList re
 
     usedVariables :: [Text]
     usedVariables = concatMap getVariablesFromDataConstructor dcs

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -344,7 +344,7 @@ instances st@(SumType t dcs is) = nub $ go <$> is
     go DecodeJson =
         mkInstance
             (mkType "DecodeJson" [t])
-            decodeJsonConstraints
+            (constrainWith "DecodeJson")
             ["decodeJson = defer \\_ -> genericDecodeAeson Argonaut.defaultOptions"]
     {-|
       This relies on unpublished PureScript library `purescript-bridge-json-helpers`:

--- a/src/Language/PureScript/Bridge/Printer.hs
+++ b/src/Language/PureScript/Bridge/Printer.hs
@@ -8,7 +8,6 @@
 module Language.PureScript.Bridge.Printer where
 
 import           Data.Char (isLower)
-import           Debug.Trace
 
 import           Control.Arrow ((&&&))
 import           Control.Lens (to, (%~), (<>~), (^.))
@@ -494,9 +493,6 @@ typeToEncode (TypeInfo "purescript-either" "Data.Either" "Either" [l, r]) =
 typeToEncode (TypeInfo "purescript-tuples" "Data.Tuple" "Tuple" ts) =
     parens $
         "E.tuple" <+> parens (hsep $ punctuate " >/\\<" $ typeToEncode <$> flattenTuple ts)
-typeToEncode (TypeInfo "purescript-tuples" "Data.Tuple" "Tuple" ts) =
-    parens $
-        "E.tuple" <+> parens (hsep $ punctuate " >/\\<" $ typeToEncode <$> flattenTuple ts)
 typeToEncode (TypeInfo "purescript-ordered-collections" "Data.Map" "Map" [k, v]) =
     parens $
         "E.dictionary" <+> typeToEncode k <+> typeToEncode v
@@ -770,7 +766,7 @@ mkType :: Text -> [PSType] -> PSType
 mkType = TypeInfo "" ""
 
 typeParams :: PSType -> [PSType]
-typeParams = filter (isLower . T.head . _typeName) . flattenTypeInfo
+typeParams = filter (maybe False (isLower . fst) . T.uncons . _typeName) . flattenTypeInfo
 
 encloseHsep :: Doc -> Doc -> Doc -> [Doc] -> Doc
 encloseHsep left right sp ds =

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -429,7 +429,7 @@ instanceToImportLines DecodeJson =
           $ Set.fromList ["defaultOptions"]
         , ImportLine "Data.Argonaut.Decode.Class" (Just "Argonaut") mempty
         , ImportLine "Data.Argonaut.Decode.Class" Nothing
-          $ Set.fromList ["class DecodeJson", "class DecodeJsonField", "decodeJson"]
+          $ Set.fromList ["class DecodeJson", "decodeJson"]
         , ImportLine "Control.Lazy" Nothing $ Set.fromList ["defer"]
         ]
 {-|
@@ -463,6 +463,8 @@ instanceToImportLines DecodeJsonHelper =
         , ImportLine "Data.Tuple.Nested" Nothing $ Set.singleton "(/\\)"
         , ImportLine "Data.Argonaut.Decode.Aeson" (Just "D") mempty
         , ImportLine "Data.Map" (Just "Map") mempty
+        , ImportLine "Data.Argonaut.Decode.Class" Nothing
+          $ Set.singleton "class DecodeJsonField"
         ]
         <> instanceToImportLines DecodeJson
 instanceToImportLines (ForeignObject _ _) =

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -467,7 +467,11 @@ instanceToImportLines Lenses =
         [ ImportLine "Data.Lens" Nothing
           $ Set.fromList [ "Iso'", "Lens'", "Prism'", "iso", "lens", "prism'" ]
         ]
-instanceToImportLines Prisms = instanceToImportLines Prisms
+instanceToImportLines Prisms =
+    importsFromList
+        [ ImportLine "Data.Lens" Nothing
+          $ Set.fromList [ "Prism'", "prism'" ]
+        ]
 instanceToImportLines (Custom _) = mempty
 instanceToImportLines Generic = mempty
 instanceToImportLines Newtype =

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -24,6 +24,7 @@ module Language.PureScript.Bridge.SumType
     , functor
     , foldable
     , traversable
+    , excludeFields
     , DataConstructor (..)
     , GDataConstructor
     , RecordEntry (..)
@@ -256,6 +257,26 @@ lenses (SumType ti dc is) = SumType ti dc . nub $ Lenses : is
 
 prisms :: SumType t -> SumType t
 prisms (SumType ti dc is) = SumType ti dc . nub $ Prisms : is
+
+-- | Remove fields by name from record constructors. Non-record constructors
+-- are left unchanged. If all fields are excluded, the constructor becomes
+-- nullary.
+--
+-- This is useful for server-only fields (e.g., @created@, @updated@) that
+-- the client doesn't need. PureScript's JSON decoder silently ignores
+-- extra fields in the wire format, so excluding them is safe.
+--
+-- @
+-- excludeFields [\"created\", \"updated\"] $ mkSumType \@Property
+-- @
+excludeFields :: [Text] -> SumType t -> SumType t
+excludeFields names (SumType ti dcs is) = SumType ti (map go dcs) is
+  where
+    go (DataConstructor n (Record entries)) =
+      case NE.filter (\e -> _recLabel e `notElem` names) entries of
+        []     -> DataConstructor n Nullary
+        (x:xs) -> DataConstructor n (Record (x NE.:| xs))
+    go dc = dc
 
 data DataConstructor (lang :: Language) = DataConstructor
   { _sigConstructor :: !Text

--- a/src/Language/PureScript/Bridge/SumType.hs
+++ b/src/Language/PureScript/Bridge/SumType.hs
@@ -22,6 +22,8 @@ module Language.PureScript.Bridge.SumType
     , jsonHelpers
     , genericShow
     , functor
+    , foldable
+    , traversable
     , DataConstructor (..)
     , GDataConstructor
     , RecordEntry (..)
@@ -157,6 +159,8 @@ data Instance (lang :: Language)
   }
   | Newtype
   | Functor
+  | Foldable
+  | Traversable
   | Eq
   | Eq1
   | Ord
@@ -222,6 +226,18 @@ your responsibility to ensure your type is a functor.
 -}
 functor :: SumType t -> SumType t
 functor (SumType ti dc is) = SumType ti dc . nub $ Functor : is
+
+{- | Ensure that a foldable instance is generated for your type. It is
+your responsibility to ensure your type is foldable.
+-}
+foldable :: SumType t -> SumType t
+foldable (SumType ti dc is) = SumType ti dc . nub $ Foldable : is
+
+{- | Ensure that a traversable instance is generated for your type. It is
+your responsibility to ensure your type is traversable.
+-}
+traversable :: SumType t -> SumType t
+traversable (SumType ti dc is) = SumType ti dc . nub $ Traversable : is
 
 -- | Ensure that an `Eq` instance is generated for your type.
 equal :: SumType t -> SumType t
@@ -355,6 +371,10 @@ instanceToTypes Newtype =
     pure . constraintToType $ TypeInfo "purescript-newtype" "Data.Newtype" "Newtype" []
 instanceToTypes Functor =
     pure . constraintToType $ TypeInfo "purescript-prelude" "Prelude" "Functor" []
+instanceToTypes Foldable =
+    pure . constraintToType $ TypeInfo "purescript-foldable-traversable" "Data.Foldable" "Foldable" []
+instanceToTypes Traversable =
+    pure . constraintToType $ TypeInfo "purescript-foldable-traversable" "Data.Traversable" "Traversable" []
 instanceToTypes Eq =
     pure . constraintToType $ TypeInfo "purescript-prelude" "Prelude" "Eq" []
 instanceToTypes Eq1 =
@@ -482,6 +502,10 @@ instanceToImportLines Newtype =
         , ImportLine "Data.Newtype" Nothing $ Set.fromList ["class Newtype"]
         ]
 instanceToImportLines Functor = mempty
+instanceToImportLines Foldable =
+    importsFromList [ImportLine "Data.Foldable" Nothing $ Set.singleton "class Foldable"]
+instanceToImportLines Traversable =
+    importsFromList [ImportLine "Data.Traversable" Nothing $ Set.singleton "class Traversable"]
 instanceToImportLines Eq = mempty
 instanceToImportLines Eq1 = mempty
 instanceToImportLines Ord = mempty

--- a/test/BuilderSpec.hs
+++ b/test/BuilderSpec.hs
@@ -1,0 +1,135 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module BuilderSpec (spec) where
+
+import           Control.Exception (evaluate)
+import           Language.PureScript.Bridge.Builder (BridgePart, buildBridge,
+                                                     buildBridgeWithCustomFixUp,
+                                                     clearPackageFixUp,
+                                                     doCheck, errorFixUp,
+                                                     psTypeParameters, (^==),
+                                                     (<|>))
+import           Language.PureScript.Bridge.PSTypes (psInt, psNumber, psString)
+import           Language.PureScript.Bridge.Primitives (intBridge)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..), mkTypeInfo,
+                                                      typeModule, typeName)
+import           Test.Hspec (Spec, anyException, describe, it, shouldThrow)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldNotBe)
+
+spec :: Spec
+spec = do
+    describe "buildBridge" $ do
+        it "with matching bridge returns correct PSType" $ do
+            let bridge :: BridgePart
+                bridge = typeName ^== "Int" >> return psInt
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` psInt
+
+        it "with no matching bridge falls back to clearPackageFixUp" $ do
+            let bridge :: BridgePart
+                bridge = typeName ^== "NONEXISTENT" >> return psInt
+                result = buildBridge bridge (mkTypeInfo @Int)
+            -- clearPackageFixUp copies module and name, clears package
+            _typeName result `shouldBe` "Int"
+            _typePackage result `shouldBe` ""
+
+    describe "buildBridgeWithCustomFixUp" $ do
+        it "errorFixUp errors on unknown type" $ do
+            let bridge :: BridgePart
+                bridge = typeName ^== "NONEXISTENT" >> return psInt
+                result = buildBridgeWithCustomFixUp errorFixUp bridge (mkTypeInfo @Int)
+            evaluate (seq result ()) `shouldThrow` anyException
+
+    describe "(^==)" $ do
+        it "matches when equal" $ do
+            let bridge :: BridgePart
+                bridge = typeName ^== "Int" >> return psString
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` psString
+
+        it "does not match when unequal (falls back)" $ do
+            let bridge :: BridgePart
+                bridge = typeName ^== "Bool" >> return psString
+                result = buildBridge bridge (mkTypeInfo @Int)
+            -- Falls back to clearPackageFixUp, not psString
+            result `shouldNotBe` psString
+
+        it "can check typeModule" $ do
+            let bridge :: BridgePart
+                bridge = do
+                    typeName ^== "Int"
+                    typeModule ^== _typeModule (mkTypeInfo @Int)
+                    return psNumber
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` psNumber
+
+    describe "doCheck" $ do
+        it "passes with true predicate" $ do
+            let bridge :: BridgePart
+                bridge = doCheck typeName (== "Int") >> return psString
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` psString
+
+        it "fails with false predicate (falls back)" $ do
+            let bridge :: BridgePart
+                bridge = doCheck typeName (== "Bool") >> return psString
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldNotBe` psString
+
+    describe "Alternative (<|>)" $ do
+        it "first match wins" $ do
+            let b1 :: BridgePart
+                b1 = typeName ^== "Int" >> return psInt
+                b2 :: BridgePart
+                b2 = typeName ^== "Int" >> return psString
+                result = buildBridge (b1 <|> b2) (mkTypeInfo @Int)
+            result `shouldBe` psInt
+
+        it "falls back to second when first fails" $ do
+            let b1 :: BridgePart
+                b1 = typeName ^== "Bool" >> return psInt
+                b2 :: BridgePart
+                b2 = typeName ^== "Int" >> return psString
+                result = buildBridge (b1 <|> b2) (mkTypeInfo @Int)
+            result `shouldBe` psString
+
+        it "falls back to fixup when both fail" $ do
+            let b1 :: BridgePart
+                b1 = typeName ^== "Bool" >> return psInt
+                b2 :: BridgePart
+                b2 = typeName ^== "Bool" >> return psString
+                result = buildBridge (b1 <|> b2) (mkTypeInfo @Int)
+            _typePackage result `shouldBe` ""
+            _typeName result `shouldBe` "Int"
+
+    describe "fixTypeParameters (via buildBridge)" $ do
+        it "lowercases and strips module for TypeParameters types" $ do
+            let bridge :: BridgePart
+                bridge = return $ TypeInfo "some-pkg" "Foo.TypeParameters" "A" []
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` TypeInfo "" "" "a" []
+
+        it "strips trailing '1' from TypeParameters names" $ do
+            let bridge :: BridgePart
+                bridge = return $ TypeInfo "some-pkg" "Foo.TypeParameters" "A1" []
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` TypeInfo "" "" "a" []
+
+        it "leaves non-TypeParameters types unchanged" $ do
+            let bridge :: BridgePart
+                bridge = return $ TypeInfo "my-pkg" "My.Module" "MyType" []
+                result = buildBridge bridge (mkTypeInfo @Int)
+            result `shouldBe` TypeInfo "my-pkg" "My.Module" "MyType" []
+
+    describe "psTypeParameters (via buildBridge)" $ do
+        it "bridges type parameters using the full bridge" $ do
+            let myBridge :: BridgePart
+                myBridge = do
+                    typeName ^== "Maybe"
+                    params <- psTypeParameters
+                    return $ TypeInfo "my-pkg" "My.Module" "MyMaybe" params
+                combined = myBridge <|> intBridge
+                result = buildBridge combined (mkTypeInfo @(Maybe Int))
+            result `shouldBe` TypeInfo "my-pkg" "My.Module" "MyMaybe" [psInt]

--- a/test/PSTypesSpec.hs
+++ b/test/PSTypesSpec.hs
@@ -1,0 +1,79 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module PSTypesSpec (spec) where
+
+import           Language.PureScript.Bridge.PSTypes (psBool, psInt, psNumber,
+                                                     psString, psUnit, psWord,
+                                                     psWord16, psWord32,
+                                                     psWord64, psWord8)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..))
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe)
+
+spec :: Spec
+spec = do
+    describe "psBool" $ do
+        it "has correct module and name" $ do
+            _typeModule psBool `shouldBe` "Prim"
+            _typeName psBool `shouldBe` "Boolean"
+            _typePackage psBool `shouldBe` ""
+            _typeParameters psBool `shouldBe` []
+
+    describe "psInt" $ do
+        it "has correct module and name" $ do
+            _typeModule psInt `shouldBe` "Prim"
+            _typeName psInt `shouldBe` "Int"
+            _typePackage psInt `shouldBe` ""
+            _typeParameters psInt `shouldBe` []
+
+    describe "psNumber" $ do
+        it "has correct module and name" $ do
+            _typeModule psNumber `shouldBe` "Prim"
+            _typeName psNumber `shouldBe` "Number"
+            _typePackage psNumber `shouldBe` ""
+            _typeParameters psNumber `shouldBe` []
+
+    describe "psString" $ do
+        it "has correct module and name" $ do
+            _typeModule psString `shouldBe` "Prim"
+            _typeName psString `shouldBe` "String"
+            _typePackage psString `shouldBe` ""
+            _typeParameters psString `shouldBe` []
+
+    describe "psUnit" $ do
+        it "has correct package, module, and name" $ do
+            _typePackage psUnit `shouldBe` "purescript-prelude"
+            _typeModule psUnit `shouldBe` "Prelude"
+            _typeName psUnit `shouldBe` "Unit"
+            _typeParameters psUnit `shouldBe` []
+
+    describe "psWord" $ do
+        it "has correct package, module, and name" $ do
+            _typePackage psWord `shouldBe` "purescript-word"
+            _typeModule psWord `shouldBe` "Data.Word"
+            _typeName psWord `shouldBe` "Word"
+            _typeParameters psWord `shouldBe` []
+
+    describe "psWord8" $ do
+        it "has correct name" $ do
+            _typePackage psWord8 `shouldBe` "purescript-word"
+            _typeModule psWord8 `shouldBe` "Data.Word"
+            _typeName psWord8 `shouldBe` "Word8"
+
+    describe "psWord16" $ do
+        it "has correct name" $ do
+            _typePackage psWord16 `shouldBe` "purescript-word"
+            _typeModule psWord16 `shouldBe` "Data.Word"
+            _typeName psWord16 `shouldBe` "Word16"
+
+    describe "psWord32" $ do
+        it "has correct name" $ do
+            _typePackage psWord32 `shouldBe` "purescript-word"
+            _typeModule psWord32 `shouldBe` "Data.Word"
+            _typeName psWord32 `shouldBe` "Word32"
+
+    describe "psWord64" $ do
+        it "has correct name" $ do
+            _typePackage psWord64 `shouldBe` "purescript-word"
+            _typeModule psWord64 `shouldBe` "Data.Word"
+            _typeName psWord64 `shouldBe` "Word64"

--- a/test/PrimitivesSpec.hs
+++ b/test/PrimitivesSpec.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module PrimitivesSpec (spec) where
+
+import           Data.Map (Map)
+import           Data.Set (Set)
+import           Data.Word (Word, Word8, Word16, Word32, Word64)
+import           Language.PureScript.Bridge (defaultBridge)
+import           Language.PureScript.Bridge.Builder (buildBridge)
+import           Language.PureScript.Bridge.PSTypes (psArray, psBool, psInt,
+                                                     psNumber, psString,
+                                                     psUnit, psWord, psWord16,
+                                                     psWord32, psWord64,
+                                                     psWord8)
+import           Language.PureScript.Bridge.Primitives (boolBridge,
+                                                        doubleBridge,
+                                                        intBridge, listBridge,
+                                                        mapBridge,
+                                                        noContentBridge,
+                                                        setBridge,
+                                                        stringBridge,
+                                                        textBridge,
+                                                        unitBridge,
+                                                        word16Bridge,
+                                                        word32Bridge,
+                                                        word64Bridge,
+                                                        word8Bridge,
+                                                        wordBridge)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..), mkTypeInfo)
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldNotBe)
+
+spec :: Spec
+spec = do
+    describe "boolBridge" $ do
+        it "translates Bool to psBool" $
+            buildBridge boolBridge (mkTypeInfo @Bool) `shouldBe` psBool
+        it "rejects non-Bool types" $
+            buildBridge boolBridge (mkTypeInfo @Int) `shouldNotBe` psBool
+
+    describe "intBridge" $ do
+        it "translates Int to psInt" $
+            buildBridge intBridge (mkTypeInfo @Int) `shouldBe` psInt
+        it "rejects non-Int types" $
+            buildBridge intBridge (mkTypeInfo @Bool) `shouldNotBe` psInt
+
+    describe "doubleBridge" $ do
+        it "translates Double to psNumber" $
+            buildBridge doubleBridge (mkTypeInfo @Double) `shouldBe` psNumber
+        it "rejects non-Double types" $
+            buildBridge doubleBridge (mkTypeInfo @Int) `shouldNotBe` psNumber
+
+    describe "stringBridge" $ do
+        it "translates String to psString" $
+            buildBridge stringBridge (mkTypeInfo @String) `shouldBe` psString
+
+    describe "textBridge" $ do
+        it "translates Text to psString" $ do
+            let result = buildBridge textBridge (mkTypeInfo @String)
+            -- textBridge checks for typeName == "Text", String won't match
+            result `shouldNotBe` psString
+
+    describe "unitBridge" $ do
+        it "translates () to psUnit (known bug: operator precedence)" $
+            buildBridge unitBridge (mkTypeInfo @()) `shouldBe` psUnit
+        it "translates types named Unit to psUnit" $ do
+            let unitType = TypeInfo "" "" "Unit" []
+            buildBridge unitBridge unitType `shouldBe` psUnit
+
+    describe "noContentBridge" $ do
+        it "translates NoContent to psUnit" $ do
+            let noContentType = TypeInfo "" "" "NoContent" []
+            buildBridge noContentBridge noContentType `shouldBe` psUnit
+
+    describe "wordBridge" $ do
+        it "translates Word to psWord" $
+            buildBridge wordBridge (mkTypeInfo @Word) `shouldBe` psWord
+
+    describe "word8Bridge" $ do
+        it "translates Word8 to psWord8" $
+            buildBridge word8Bridge (mkTypeInfo @Word8) `shouldBe` psWord8
+
+    describe "word16Bridge" $ do
+        it "translates Word16 to psWord16" $
+            buildBridge word16Bridge (mkTypeInfo @Word16) `shouldBe` psWord16
+
+    describe "word32Bridge" $ do
+        it "translates Word32 to psWord32" $
+            buildBridge word32Bridge (mkTypeInfo @Word32) `shouldBe` psWord32
+
+    describe "word64Bridge" $ do
+        it "translates Word64 to psWord64" $
+            buildBridge word64Bridge (mkTypeInfo @Word64) `shouldBe` psWord64
+
+    describe "listBridge" $ do
+        it "translates [Int] — list type gets Array with bridged params" $ do
+            let result = buildBridge (listBridge) (mkTypeInfo @[Int])
+            _typeName result `shouldBe` "Array"
+
+    describe "setBridge" $ do
+        it "matches Data.Set.Internal" $ do
+            let result = buildBridge setBridge (mkTypeInfo @(Set Int))
+            _typeName result `shouldBe` "Set"
+            _typeModule result `shouldBe` "Data.Set"
+
+    describe "mapBridge" $ do
+        it "matches Data.Map.Internal" $ do
+            let result = buildBridge mapBridge (mkTypeInfo @(Map String Int))
+            _typeName result `shouldBe` "Map"
+            _typeModule result `shouldBe` "Data.Map"
+
+    describe "defaultBridge" $ do
+        it "handles all primitive types" $ do
+            let bridge = buildBridge defaultBridge
+            bridge (mkTypeInfo @Bool) `shouldBe` psBool
+            bridge (mkTypeInfo @Int) `shouldBe` psInt
+            bridge (mkTypeInfo @Double) `shouldBe` psNumber
+            bridge (mkTypeInfo @String) `shouldBe` psString
+            bridge (mkTypeInfo @Word) `shouldBe` psWord
+            bridge (mkTypeInfo @()) `shouldBe` psUnit

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -15,7 +15,8 @@ import           Language.PureScript.Bridge.Printer (Module (PSModule, psModuleN
                                                      constructorPattern,
                                                      constructor,
                                                      flattenTuple, hasUnderscore,
-                                                     isEnum, mkPackageName,
+                                                     instances, isEnum,
+                                                     mkPackageName,
                                                      renderText, sumTypeToModule,
                                                      sumTypesToModules, typeParams,
                                                      typeToImportLines,
@@ -26,6 +27,7 @@ import           Language.PureScript.Bridge.PSTypes (psInt, psString, psUnit)
 import           Language.PureScript.Bridge.SumType (DataConstructor (..),
                                                      DataConstructorArgs (..),
                                                      ImportLine (..),
+                                                     Instance (..),
                                                      RecordEntry (..),
                                                      SumType (..),
                                                      importsFromList)
@@ -208,6 +210,88 @@ spec = do
         it "Record produces record expression" $ do
             let args = Record (NE.singleton $ RecordEntry "x" psInt) :: DataConstructorArgs 'PureScript
             renderText (constructor args) `shouldSatisfy` T.isInfixOf "x"
+
+    describe "instances" $ do
+        it "GenericShow adds Show constraint for type variable nested in constructor" $ do
+            -- data Request a = Write Int (NonEmptyArray a)
+            let typeVar = TypeInfo "" "" "a" []
+                wrappedA = TypeInfo "" "" "NonEmptyArray" [typeVar]
+                requestType = TypeInfo "" "" "Request" [typeVar]
+                dc = DataConstructor "Write" (Normal $ psInt NE.:| [wrappedA])
+                st = SumType requestType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+
+        it "GenericShow omits constraint for phantom type variable" $ do
+            -- data Phantom a = Phantom Int
+            let typeVar = TypeInfo "" "" "a" []
+                phantomType = TypeInfo "" "" "Phantom" [typeVar]
+                dc = DataConstructor "Phantom" (Normal $ NE.singleton psInt)
+                st = SumType phantomType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` (not . T.isInfixOf "(Show a) =>")
+
+        it "GenericShow adds constraint for directly used type variable" $ do
+            -- data Box a = Box a
+            let typeVar = TypeInfo "" "" "a" []
+                boxType = TypeInfo "" "" "Box" [typeVar]
+                dc = DataConstructor "Box" (Normal $ NE.singleton typeVar)
+                st = SumType boxType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+
+        it "GenericShow adds constraint for type variable in record field" $ do
+            -- data Foo a = Foo { items :: Array a }
+            let typeVar = TypeInfo "" "" "a" []
+                arrayA = TypeInfo "" "" "Array" [typeVar]
+                fooType = TypeInfo "" "" "Foo" [typeVar]
+                dc = DataConstructor "Foo" (Record $ NE.singleton $ RecordEntry "items" arrayA)
+                st = SumType fooType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+
+        it "GenericShow adds constraint for deeply nested type variable" $ do
+            -- data Foo a = Foo (Maybe (Array a))
+            let typeVar = TypeInfo "" "" "a" []
+                arrayA = TypeInfo "" "" "Array" [typeVar]
+                maybeArrayA = TypeInfo "" "" "Maybe" [arrayA]
+                fooType = TypeInfo "" "" "Foo" [typeVar]
+                dc = DataConstructor "Foo" (Normal $ NE.singleton maybeArrayA)
+                st = SumType fooType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+
+        it "GenericShow handles multiple type params, one nested one phantom" $ do
+            -- data Foo a b = Foo (Array a)
+            let a = TypeInfo "" "" "a" []
+                b = TypeInfo "" "" "b" []
+                arrayA = TypeInfo "" "" "Array" [a]
+                fooType = TypeInfo "" "" "Foo" [a, b]
+                dc = DataConstructor "Foo" (Normal $ NE.singleton arrayA)
+                st = SumType fooType [dc] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+            rendered `shouldSatisfy` (not . T.isInfixOf "(Show b)")
+
+        it "GenericShow finds variable used in only one of multiple constructors" $ do
+            -- data Foo a = Empty | Full (Array a)
+            let typeVar = TypeInfo "" "" "a" []
+                arrayA = TypeInfo "" "" "Array" [typeVar]
+                fooType = TypeInfo "" "" "Foo" [typeVar]
+                dc1 = DataConstructor "Empty" Nullary
+                dc2 = DataConstructor "Full" (Normal $ NE.singleton arrayA)
+                st = SumType fooType [dc1, dc2] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "(Show a) =>"
+
+        it "GenericShow with no type parameters produces no constraints" $ do
+            -- data Color = Red | Blue
+            let colorType = TypeInfo "" "" "Color" []
+                dc1 = DataConstructor "Red" Nullary
+                dc2 = DataConstructor "Blue" Nullary
+                st = SumType colorType [dc1, dc2] [GenericShow]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` (not . T.isInfixOf "=>")
 
   where
     mkTestModule :: T.Text -> [ImportLine] -> [T.Text] -> Module 'PureScript

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -1,0 +1,221 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module PrinterSpec (spec) where
+
+import           Data.Maybe (isJust, isNothing)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import qualified Data.Text as T
+import           Language.PureScript.Bridge (bridgeSumType, buildBridge,
+                                             defaultBridge, mkSumType)
+import           Language.PureScript.Bridge.Printer (Module (PSModule, psModuleName, psImportLines, psQualifiedImports, psTypes),
+                                                     constructorPattern,
+                                                     constructor,
+                                                     flattenTuple, hasUnderscore,
+                                                     isEnum, mkPackageName,
+                                                     renderText, sumTypeToModule,
+                                                     sumTypesToModules, typeParams,
+                                                     typeToImportLines,
+                                                     unionImportLine,
+                                                     unionImportLines,
+                                                     unionModules)
+import           Language.PureScript.Bridge.PSTypes (psInt, psString, psUnit)
+import           Language.PureScript.Bridge.SumType (DataConstructor (..),
+                                                     DataConstructorArgs (..),
+                                                     ImportLine (..),
+                                                     RecordEntry (..),
+                                                     SumType (..),
+                                                     importsFromList)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..),
+                                                      Language (PureScript))
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldSatisfy)
+import           TestData (Foo, WeekInMonth)
+import           Text.PrettyPrint.Leijen.Text (textStrict)
+
+spec :: Spec
+spec = do
+    describe "renderText" $ do
+        it "renders a simple doc to text" $
+            renderText (textStrict "hello") `shouldBe` "hello"
+
+        it "renders empty doc to empty text" $
+            renderText mempty `shouldBe` ""
+
+    describe "mkPackageName" $ do
+        it "accepts valid alpha-only names" $
+            isJust (mkPackageName "MyPackage") `shouldBe` True
+
+        it "rejects names with digits" $
+            isNothing (mkPackageName "package1") `shouldBe` True
+
+        it "rejects names with special characters" $
+            isNothing (mkPackageName "my-package") `shouldBe` True
+
+        it "accepts empty string (vacuous truth: all isAlpha \"\" = True)" $
+            isJust (mkPackageName "") `shouldBe` True
+
+    describe "sumTypeToModule" $ do
+        it "produces correct module name" $ do
+            let st = bridgeSumType (buildBridge defaultBridge) (mkSumType @Foo)
+                modules = sumTypeToModule Nothing st
+            Map.size modules `shouldBe` 1
+            let modName = head $ Map.keys modules
+            modName `shouldBe` "TestData"
+
+        it "uses package name prefix when provided" $ do
+            let st = bridgeSumType (buildBridge defaultBridge) (mkSumType @Foo)
+                modules = sumTypeToModule (mkPackageName "MyApp") st
+                m = head $ Map.elems modules
+            psModuleName m `shouldSatisfy` T.isPrefixOf "MyApp."
+
+    describe "sumTypesToModules" $ do
+        it "merges types with same module" $ do
+            let bridge = buildBridge defaultBridge
+                st1 = bridgeSumType bridge (mkSumType @Foo)
+                st2 = bridgeSumType bridge (mkSumType @WeekInMonth)
+                modules = sumTypesToModules Nothing [st1, st2]
+            -- Both Foo and WeekInMonth are in TestData module
+            Map.size modules `shouldBe` 1
+
+    describe "unionModules" $ do
+        it "merges import lines and types" $ do
+            let m1 = mkTestModule "Test" [ImportLine "Data.Maybe" Nothing $ Set.singleton "Maybe"] ["Type1"]
+                m2 = mkTestModule "Test" [ImportLine "Data.Either" Nothing $ Set.singleton "Either"] ["Type2"]
+                merged = unionModules m1 m2
+            Map.size (psImportLines merged) `shouldBe` 2
+            length (psTypes merged) `shouldBe` 2
+
+    describe "unionImportLines" $ do
+        it "merges maps of import lines" $ do
+            let il1 = importsFromList [ImportLine "Data.Maybe" Nothing $ Set.singleton "Maybe"]
+                il2 = importsFromList [ImportLine "Data.Either" Nothing $ Set.singleton "Either"]
+                merged = unionImportLines il1 il2
+            Map.size merged `shouldBe` 2
+
+        it "unions import types for same module" $ do
+            let il1 = importsFromList [ImportLine "Data.Maybe" Nothing $ Set.singleton "Maybe"]
+                il2 = importsFromList [ImportLine "Data.Maybe" Nothing $ Set.singleton "fromMaybe"]
+                merged = unionImportLines il1 il2
+            Map.size merged `shouldBe` 1
+            let Just il = Map.lookup "Data.Maybe" merged
+            importTypes il `shouldBe` Set.fromList ["Maybe", "fromMaybe"]
+
+    describe "unionImportLine" $ do
+        it "unions import types" $ do
+            let l1 = ImportLine "Data.Maybe" Nothing $ Set.singleton "Maybe"
+                l2 = ImportLine "Data.Maybe" Nothing $ Set.singleton "fromMaybe"
+                merged = unionImportLine l1 l2
+            importTypes merged `shouldBe` Set.fromList ["Maybe", "fromMaybe"]
+
+    describe "typeToImportLines" $ do
+        it "creates import for simple type" $ do
+            let imports = typeToImportLines psInt
+            imports `shouldSatisfy` Map.member "Prim"
+
+        it "creates imports for parameterized type" $ do
+            let t = TypeInfo "purescript-maybe" "Data.Maybe" "Maybe" [psInt]
+            let imports = typeToImportLines t
+            imports `shouldSatisfy` Map.member "Data.Maybe"
+            imports `shouldSatisfy` Map.member "Prim"
+
+    describe "isEnum" $ do
+        it "returns True when all constructors are Nullary" $ do
+            let cs = [ DataConstructor "A" Nullary
+                      , DataConstructor "B" Nullary
+                      ] :: [DataConstructor 'PureScript]
+            isEnum cs `shouldBe` True
+
+        it "returns False when any constructor is non-Nullary" $ do
+            let cs = [ DataConstructor "A" Nullary
+                      , DataConstructor "B" (Normal $ NE.singleton psInt)
+                      ] :: [DataConstructor 'PureScript]
+            isEnum cs `shouldBe` False
+
+        it "returns True for empty list" $
+            isEnum ([] :: [DataConstructor 'PureScript]) `shouldBe` True
+
+    describe "typeParams" $ do
+        it "extracts lowercase type variables" $ do
+            let t = TypeInfo "" "" "Maybe" [TypeInfo "" "" "a" []]
+                params = typeParams t
+            length params `shouldBe` 1
+            _typeName (head params) `shouldBe` "a"
+
+        it "skips uppercase type names" $ do
+            let t = TypeInfo "" "" "Maybe" [TypeInfo "" "" "Int" []]
+            typeParams t `shouldBe` []
+
+        it "extracts from nested types" $ do
+            let t = TypeInfo "" "" "Either" [TypeInfo "" "" "a" [], TypeInfo "" "" "b" []]
+                params = typeParams t
+            length params `shouldBe` 2
+
+        -- Known bug: T.head on empty _typeName crashes (Printer.hs:773)
+        it "handles empty typeName without crashing (known bug: partial T.head)" $ do
+            let t = TypeInfo "" "" "" [] :: TypeInfo 'PureScript
+            typeParams t `shouldBe` []
+
+    describe "flattenTuple" $ do
+        it "passes through empty list" $
+            flattenTuple [] `shouldBe` ([] :: [TypeInfo 'PureScript])
+
+        it "passes through singleton" $
+            flattenTuple [psInt] `shouldBe` [psInt]
+
+        it "flattens nested Tuple in second position" $ do
+            let nested = TypeInfo "purescript-tuples" "Data.Tuple" "Tuple"
+                            [psString, psInt]
+                input = [psInt, nested]
+                result = flattenTuple input
+            length result `shouldBe` 3
+
+        it "passes through non-tuple types" $
+            flattenTuple [psInt, psString] `shouldBe` [psInt, psString]
+
+    describe "hasUnderscore" $ do
+        it "returns True for names starting with _" $ do
+            let re = RecordEntry "_foo" psInt :: RecordEntry 'PureScript
+            hasUnderscore re `shouldBe` True
+
+        it "returns False for names not starting with _" $ do
+            let re = RecordEntry "foo" psInt :: RecordEntry 'PureScript
+            hasUnderscore re `shouldBe` False
+
+    describe "constructorPattern" $ do
+        it "Nullary constructor produces just the name" $ do
+            let dc = DataConstructor "Foo" Nullary :: DataConstructor 'PureScript
+            renderText (constructorPattern dc) `shouldBe` "Foo"
+
+        it "Normal constructor produces name with variables" $ do
+            let dc = DataConstructor "Foo" (Normal $ NE.singleton psInt) :: DataConstructor 'PureScript
+            renderText (constructorPattern dc) `shouldSatisfy` T.isPrefixOf "Foo"
+
+        it "Record constructor produces name with record" $ do
+            let dc = DataConstructor "Foo" (Record $ NE.singleton $ RecordEntry "x" psInt) :: DataConstructor 'PureScript
+            renderText (constructorPattern dc) `shouldSatisfy` T.isPrefixOf "Foo"
+
+    describe "constructor" $ do
+        it "Nullary produces unit" $
+            renderText (constructor Nullary) `shouldBe` "unit"
+
+        it "Normal with single arg produces 'a'" $
+            renderText (constructor (Normal $ NE.singleton psInt)) `shouldBe` "a"
+
+        it "Record produces record expression" $ do
+            let args = Record (NE.singleton $ RecordEntry "x" psInt) :: DataConstructorArgs 'PureScript
+            renderText (constructor args) `shouldSatisfy` T.isInfixOf "x"
+
+  where
+    mkTestModule :: T.Text -> [ImportLine] -> [T.Text] -> Module 'PureScript
+    mkTestModule name imports typeNames = PSModule
+        { psModuleName = name
+        , psImportLines = importsFromList imports
+        , psQualifiedImports = Map.empty
+        , psTypes = [ SumType (TypeInfo "" name tn []) [DataConstructor tn Nullary] []
+                     | tn <- typeNames
+                     ]
+        }

--- a/test/PrinterSpec.hs
+++ b/test/PrinterSpec.hs
@@ -293,6 +293,26 @@ spec = do
                 rendered = T.unlines $ map renderText $ instances st
             rendered `shouldSatisfy` (not . T.isInfixOf "=>")
 
+        it "DecodeJson does not generate DecodeJsonField constraint" $ do
+            -- data Foo a = Foo a
+            let typeVar = TypeInfo "" "" "a" []
+                fooType = TypeInfo "" "" "Foo" [typeVar]
+                dc = DataConstructor "Foo" (Normal $ NE.singleton typeVar)
+                st = SumType fooType [dc] [DecodeJson]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "DecodeJson a"
+            rendered `shouldSatisfy` (not . T.isInfixOf "DecodeJsonField")
+
+        it "DecodeJsonHelper generates both DecodeJson and DecodeJsonField constraints" $ do
+            -- data Foo a = Foo a
+            let typeVar = TypeInfo "" "" "a" []
+                fooType = TypeInfo "" "" "Foo" [typeVar]
+                dc = DataConstructor "Foo" (Normal $ NE.singleton typeVar)
+                st = SumType fooType [dc] [DecodeJsonHelper]
+                rendered = T.unlines $ map renderText $ instances st
+            rendered `shouldSatisfy` T.isInfixOf "DecodeJson a"
+            rendered `shouldSatisfy` T.isInfixOf "DecodeJsonField a"
+
   where
     mkTestModule :: T.Text -> [ImportLine] -> [T.Text] -> Module 'PureScript
     mkTestModule name imports typeNames = PSModule

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -22,8 +22,10 @@ import           Language.PureScript.Bridge (CustomInstance (CustomInstance),
                                              TypeInfo (TypeInfo, _typeModule, _typeName, _typePackage, _typeParameters),
                                              bridgeSumType, buildBridge,
                                              defaultBridge, equal, equal1,
-                                             functor, genericShow, mkSumType,
-                                             mkTypeInfo, moduleToText, order,
+                                             foldable, functor, genericShow,
+                                             mkSumType, traversable,
+                                             mkTypeInfo, moduleToText,
+                                             order,
                                              renderText, sumTypeToDocs,
                                              sumTypeToModule)
 import           Language.PureScript.Bridge.TypeParameters (A, B, C, M1)
@@ -38,7 +40,7 @@ import qualified SumTypeSpec
 import           Test.Hspec (Spec, describe, hspec, it)
 import qualified TupleSpec
 import qualified TypeInfoSpec
-import           Test.Hspec.Expectations.Pretty (Expectation, shouldBe)
+import           Test.Hspec.Expectations.Pretty (Expectation, shouldBe, shouldSatisfy)
 import           TestData (Bar, Foo, Func, Simple, SingleProduct, SingleRecord,
                            SingleValueConstr, SomeNewtype, WeekInMonth,
                            weekInMonth)
@@ -196,6 +198,35 @@ allTests = do
                         derive instance Generic (Func a) _
                         |]
              in doc `shouldRender` txt
+        it "tests generation of Functor, Foldable, and Traversable instances" $
+            let sumType =
+                    bridgeSumType
+                        (buildBridge defaultBridge)
+                        (functor . foldable . traversable $ mkSumType @(Func A))
+                doc = vsep $ sumTypeToDocs sumType
+                txt = [trimming|
+                        data Func a = Func Int a
+
+                        derive instance Functor Func
+
+                        derive instance Foldable Func
+
+                        derive instance Traversable Func
+
+                        derive instance Generic (Func a) _
+                        |]
+             in doc `shouldRender` txt
+        it "tests module generation with Foldable and Traversable imports" $
+            let sumType =
+                    bridgeSumType
+                        (buildBridge defaultBridge)
+                        (functor . foldable . traversable $ mkSumType @(Func A))
+                modules :: Modules
+                modules = sumTypeToModule Nothing sumType
+                m = head . map moduleToText . Map.elems $ modules
+             in do
+                m `shouldSatisfy` T.isInfixOf "import Data.Foldable (class Foldable)"
+                m `shouldSatisfy` T.isInfixOf "import Data.Traversable (class Traversable)"
         it "tests the generation of a whole (dummy) module" $
             let advanced' :: SumType 'PureScript
                 advanced' =

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -28,9 +28,16 @@ import           Language.PureScript.Bridge (CustomInstance (CustomInstance),
                                              sumTypeToModule)
 import           Language.PureScript.Bridge.TypeParameters (A, B, C, M1)
 import           NeatInterpolation (trimming, untrimming)
+import qualified BuilderSpec
+import qualified PrimitivesSpec
+import qualified PrinterSpec
+import qualified PSTypesSpec
 import qualified RoundTripArgonautAesonGeneric.Spec (roundtripSpec)
 import qualified RoundTripJsonHelpers.Spec (roundtripSpec)
+import qualified SumTypeSpec
 import           Test.Hspec (Spec, describe, hspec, it)
+import qualified TupleSpec
+import qualified TypeInfoSpec
 import           Test.Hspec.Expectations.Pretty (Expectation, shouldBe)
 import           TestData (Bar, Foo, Func, Simple, SingleProduct, SingleRecord,
                            SingleValueConstr, SomeNewtype, WeekInMonth,
@@ -47,7 +54,15 @@ import           Text.PrettyPrint.Leijen.Text (Doc, cat, linebreak, punctuate,
 -- Spago project will fail to build because of module name duplication.
 main :: IO ()
 main =
-  hspec $ allTests
+  hspec $ do
+    allTests
+    describe "TypeInfo" TypeInfoSpec.spec
+    describe "Tuple" TupleSpec.spec
+    describe "Builder" BuilderSpec.spec
+    describe "Primitives" PrimitivesSpec.spec
+    describe "SumType" SumTypeSpec.spec
+    describe "Printer" PrinterSpec.spec
+    describe "PSTypes" PSTypesSpec.spec
   *> RoundTripArgonautAesonGeneric.Spec.roundtripSpec
   *> RoundTripJsonHelpers.Spec.roundtripSpec
 

--- a/test/SumTypeSpec.hs
+++ b/test/SumTypeSpec.hs
@@ -18,7 +18,8 @@ import           Language.PureScript.Bridge.SumType (DataConstructor (..),
                                                      SumType (..),
                                                      constructorToTypes,
                                                      equal, equal1,
-                                                     functor, genericShow,
+                                                     foldable, functor,
+                                                     genericShow, traversable,
                                                      getUsedTypes,
                                                      importsFromList,
                                                      instanceToImportLines,
@@ -124,6 +125,14 @@ spec = do
             let SumType _ _ is = functor $ mkSumType @Foo
             is `shouldSatisfy` elem Functor
 
+        it "foldable adds Foldable instance" $ do
+            let SumType _ _ is = foldable $ mkSumType @Foo
+            is `shouldSatisfy` elem Foldable
+
+        it "traversable adds Traversable instance" $ do
+            let SumType _ _ is = traversable $ mkSumType @Foo
+            is `shouldSatisfy` elem Traversable
+
         it "lenses adds Lenses instance" $ do
             let SumType _ _ is = lenses $ mkSumType @Foo
             is `shouldSatisfy` elem Lenses
@@ -197,6 +206,14 @@ spec = do
 
         it "Functor produces empty imports" $
             instanceToImportLines Functor `shouldBe` Map.empty
+
+        it "Foldable imports Data.Foldable" $ do
+            let imports = instanceToImportLines Foldable
+            imports `shouldSatisfy` Map.member "Data.Foldable"
+
+        it "Traversable imports Data.Traversable" $ do
+            let imports = instanceToImportLines Traversable
+            imports `shouldSatisfy` Map.member "Data.Traversable"
 
         it "Lenses imports Data.Lens" $ do
             let imports = instanceToImportLines Lenses

--- a/test/SumTypeSpec.hs
+++ b/test/SumTypeSpec.hs
@@ -1,0 +1,277 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module SumTypeSpec (spec) where
+
+import           Control.Exception (evaluate)
+import           Data.Maybe (isJust)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map as Map
+import qualified Data.Set as Set
+import           System.Timeout (timeout)
+import           Language.PureScript.Bridge.SumType (DataConstructor (..),
+                                                     DataConstructorArgs (..),
+                                                     ImportLine (..),
+                                                     Instance (..),
+                                                     RecordEntry (..),
+                                                     SumType (..),
+                                                     constructorToTypes,
+                                                     equal, equal1,
+                                                     functor, genericShow,
+                                                     getUsedTypes,
+                                                     importsFromList,
+                                                     instanceToImportLines,
+                                                     baselineImports,
+                                                     lenses, mkSumType,
+                                                     nootype, order, prisms)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..), mkTypeInfo,
+                                                      Language (Haskell, PureScript))
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldSatisfy)
+import           TestData (Foo, SingleRecord, SomeNewtype, WeekInMonth,
+                           SingleValueConstr, SingleProduct)
+import           Language.PureScript.Bridge.TypeParameters (A, B)
+
+spec :: Spec
+spec = do
+    describe "mkSumType" $ do
+        it "creates enum type (all Nullary constructors)" $ do
+            let SumType ti cs is = mkSumType @WeekInMonth
+            _typeName ti `shouldBe` "WeekInMonth"
+            length cs `shouldBe` 5
+            all (\(DataConstructor _ args) -> args == Nullary) cs `shouldBe` True
+
+        it "includes Generic instance by default" $ do
+            let SumType _ _ is = mkSumType @WeekInMonth
+            is `shouldSatisfy` elem Generic
+
+        it "creates record newtype (gets Newtype instance)" $ do
+            let SumType _ _ is = mkSumType @(SingleRecord A B)
+            is `shouldSatisfy` elem Newtype
+
+        it "creates sum type with mixed constructors" $ do
+            let SumType ti cs _ = mkSumType @Foo
+            _typeName ti `shouldBe` "Foo"
+            length cs `shouldBe` 3
+            -- Foo has: Foo (Nullary), Bar Int (Normal), FooBar Int Text (Normal)
+            let args = map (\(DataConstructor _ a) -> a) cs
+            head args `shouldBe` Nullary
+
+        it "creates newtype for single Normal constructor" $ do
+            let SumType _ _ is = mkSumType @SomeNewtype
+            is `shouldSatisfy` elem Newtype
+
+        it "creates newtype for data type with one value constructor" $ do
+            let SumType _ _ is = mkSumType @SingleValueConstr
+            is `shouldSatisfy` elem Newtype
+
+        it "does not create Newtype for multi-constructor type" $ do
+            let SumType _ _ is = mkSumType @Foo
+            is `shouldSatisfy` notElem Newtype
+
+        it "does not create Newtype for product type with two args" $ do
+            let SumType _ _ is = mkSumType @SingleProduct
+            is `shouldSatisfy` notElem Newtype
+
+    describe "nootype" $ do
+        it "returns Just Newtype for single record constructor" $ do
+            let cs = [DataConstructor "Foo" (Record $ NE.singleton $ RecordEntry "x" (mkTypeInfo @Int))]
+            nootype cs `shouldBe` Just Newtype
+
+        it "returns Just Newtype for single Normal constructor with one arg" $ do
+            let cs = [DataConstructor "Foo" (Normal $ NE.singleton $ mkTypeInfo @Int)]
+            nootype cs `shouldBe` Just Newtype
+
+        it "returns Nothing for multiple constructors" $ do
+            let cs = [ DataConstructor "Foo" Nullary
+                      , DataConstructor "Bar" Nullary
+                      ]
+            nootype cs `shouldBe` Nothing
+
+        it "returns Nothing for single Nullary constructor" $ do
+            let cs = [DataConstructor "Foo" Nullary]
+            nootype cs `shouldBe` Nothing
+
+        it "returns Nothing for single Normal constructor with multiple args" $ do
+            let cs = [DataConstructor "Foo" (Normal $ mkTypeInfo @Int NE.:| [mkTypeInfo @Bool])]
+            nootype cs `shouldBe` Nothing
+
+    describe "instance modifiers" $ do
+        it "equal adds Eq instance" $ do
+            let SumType _ _ is = equal $ mkSumType @Foo
+            is `shouldSatisfy` elem Eq
+
+        it "equal is idempotent" $ do
+            let SumType _ _ is1 = equal $ mkSumType @Foo
+                SumType _ _ is2 = equal . equal $ mkSumType @Foo
+            is1 `shouldBe` is2
+
+        it "equal1 adds Eq1 instance" $ do
+            let SumType _ _ is = equal1 $ mkSumType @Foo
+            is `shouldSatisfy` elem Eq1
+
+        it "order adds Eq and Ord instances" $ do
+            let SumType _ _ is = order $ mkSumType @Foo
+            is `shouldSatisfy` elem Eq
+            is `shouldSatisfy` elem Ord
+
+        it "genericShow adds GenericShow instance" $ do
+            let SumType _ _ is = genericShow $ mkSumType @Foo
+            is `shouldSatisfy` elem GenericShow
+
+        it "functor adds Functor instance" $ do
+            let SumType _ _ is = functor $ mkSumType @Foo
+            is `shouldSatisfy` elem Functor
+
+        it "lenses adds Lenses instance" $ do
+            let SumType _ _ is = lenses $ mkSumType @Foo
+            is `shouldSatisfy` elem Lenses
+
+        it "prisms adds Prisms instance" $ do
+            let SumType _ _ is = prisms $ mkSumType @Foo
+            is `shouldSatisfy` elem Prisms
+
+    describe "getUsedTypes" $ do
+        it "collects types from constructors" $ do
+            let st = mkSumType @Foo
+                used = getUsedTypes st
+            -- Foo has constructors using Int and Text types
+            used `shouldSatisfy` (not . Set.null)
+
+        it "collects types from instances" $ do
+            let st = mkSumType @WeekInMonth
+                used = getUsedTypes st
+            -- Should include Generic-related types
+            used `shouldSatisfy` (not . Set.null)
+
+        it "includes Generic type info" $ do
+            let st = mkSumType @WeekInMonth
+                used = getUsedTypes st
+                names = Set.map _typeName used
+            names `shouldSatisfy` Set.member "class Generic"
+
+    describe "constructorToTypes" $ do
+        it "returns empty for Nullary" $ do
+            let dc = DataConstructor "Foo" Nullary :: DataConstructor 'Haskell
+            constructorToTypes dc `shouldBe` []
+
+        it "returns types for Normal" $ do
+            let ti = mkTypeInfo @Int
+                dc = DataConstructor "Foo" (Normal $ NE.singleton ti)
+            constructorToTypes dc `shouldBe` [ti]
+
+        it "returns record values for Record" $ do
+            let ti = mkTypeInfo @Int
+                dc = DataConstructor "Foo" (Record $ NE.singleton $ RecordEntry "x" ti)
+            constructorToTypes dc `shouldBe` [ti]
+
+    describe "instanceToImportLines" $ do
+        it "GenericShow imports genericShow" $ do
+            let imports = instanceToImportLines GenericShow
+            imports `shouldSatisfy` Map.member "Data.Show.Generic"
+
+        it "Generic produces empty imports" $ do
+            let imports = instanceToImportLines Generic
+            imports `shouldBe` Map.empty
+
+        it "Newtype imports Data.Lens and friends" $ do
+            let imports = instanceToImportLines Newtype
+            imports `shouldSatisfy` Map.member "Data.Lens.Iso.Newtype"
+            imports `shouldSatisfy` Map.member "Data.Lens.Record"
+            imports `shouldSatisfy` Map.member "Type.Proxy"
+
+        it "Enum imports genericPred and genericSucc" $ do
+            let imports = instanceToImportLines Enum
+            imports `shouldSatisfy` Map.member "Data.Enum.Generic"
+
+        it "Bounded imports genericBottom and genericTop" $ do
+            let imports = instanceToImportLines Bounded
+            imports `shouldSatisfy` Map.member "Data.Bounded.Generic"
+
+        it "Eq produces empty imports" $
+            instanceToImportLines Eq `shouldBe` Map.empty
+
+        it "Ord produces empty imports" $
+            instanceToImportLines Ord `shouldBe` Map.empty
+
+        it "Functor produces empty imports" $
+            instanceToImportLines Functor `shouldBe` Map.empty
+
+        it "Lenses imports Data.Lens" $ do
+            let imports = instanceToImportLines Lenses
+            imports `shouldSatisfy` Map.member "Data.Lens"
+
+        -- Known bug: instanceToImportLines Prisms = instanceToImportLines Prisms
+        -- (infinite recursion at SumType.hs:470)
+        it "Prisms returns import lines (known bug: infinite recursion)" $ do
+            result <- timeout 500000 $ evaluate $ Map.size $ instanceToImportLines Prisms
+            result `shouldSatisfy` isJust
+
+    describe "importsFromList" $ do
+        it "merges imports with same module" $ do
+            let imports = importsFromList
+                    [ ImportLine "Data.Maybe" Nothing (Set.singleton "Maybe")
+                    , ImportLine "Data.Maybe" Nothing (Set.singleton "fromMaybe")
+                    ]
+            Map.size imports `shouldBe` 1
+            let Just il = Map.lookup "Data.Maybe" imports
+            importTypes il `shouldBe` Set.fromList ["Maybe", "fromMaybe"]
+
+        it "keeps aliased imports separate" $ do
+            let imports = importsFromList
+                    [ ImportLine "Data.Map" Nothing (Set.singleton "Map")
+                    , ImportLine "Data.Map" (Just "Map") Set.empty
+                    ]
+            Map.size imports `shouldBe` 2
+
+        it "filters out empty module names" $ do
+            let imports = importsFromList
+                    [ ImportLine "" Nothing (Set.singleton "Foo")
+                    , ImportLine "Data.Maybe" Nothing (Set.singleton "Maybe")
+                    ]
+            Map.size imports `shouldBe` 1
+
+    describe "baselineImports" $ do
+        it "includes Data.Maybe" $
+            baselineImports `shouldSatisfy` Map.member "Data.Maybe"
+
+        it "includes Data.Newtype" $
+            baselineImports `shouldSatisfy` Map.member "Data.Newtype"
+
+    describe "DataConstructorArgs Semigroup" $ do
+        it "Nullary <> b = b" $ do
+            let b = Normal $ NE.singleton (mkTypeInfo @Int)
+            (Nullary <> b) `shouldBe` b
+
+        it "a <> Nullary = a" $ do
+            let a = Normal $ NE.singleton (mkTypeInfo @Int) :: DataConstructorArgs 'Haskell
+            (a <> Nullary) `shouldBe` a
+
+        it "Normal <> Normal concatenates" $ do
+            let a = Normal $ NE.singleton (mkTypeInfo @Int) :: DataConstructorArgs 'Haskell
+                b = Normal $ NE.singleton (mkTypeInfo @Bool)
+                Normal result = a <> b
+            NE.length result `shouldBe` 2
+
+        it "Record <> Record concatenates" $ do
+            let a = Record $ NE.singleton (RecordEntry "x" $ mkTypeInfo @Int) :: DataConstructorArgs 'Haskell
+                b = Record $ NE.singleton (RecordEntry "y" $ mkTypeInfo @Bool)
+                Record result = a <> b
+            NE.length result `shouldBe` 2
+
+        it "Normal <> Record yields Normal (drops labels)" $ do
+            let a = Normal $ NE.singleton (mkTypeInfo @Int) :: DataConstructorArgs 'Haskell
+                b = Record $ NE.singleton (RecordEntry "y" $ mkTypeInfo @Bool)
+                result = a <> b
+            isNormal result `shouldBe` True
+
+        it "Record <> Normal yields Normal (drops labels)" $ do
+            let a = Record $ NE.singleton (RecordEntry "x" $ mkTypeInfo @Int) :: DataConstructorArgs 'Haskell
+                b = Normal $ NE.singleton (mkTypeInfo @Bool)
+                result = a <> b
+            isNormal result `shouldBe` True
+
+isNormal :: DataConstructorArgs lang -> Bool
+isNormal (Normal _) = True
+isNormal _          = False

--- a/test/SumTypeSpec.hs
+++ b/test/SumTypeSpec.hs
@@ -18,6 +18,7 @@ import           Language.PureScript.Bridge.SumType (DataConstructor (..),
                                                      SumType (..),
                                                      constructorToTypes,
                                                      equal, equal1,
+                                                     excludeFields,
                                                      foldable, functor,
                                                      genericShow, traversable,
                                                      getUsedTypes,
@@ -288,6 +289,48 @@ spec = do
                 b = Normal $ NE.singleton (mkTypeInfo @Bool)
                 result = a <> b
             isNormal result `shouldBe` True
+
+    describe "excludeFields" $ do
+        it "removes named fields from record constructor" $ do
+            let entries = RecordEntry "name" (mkTypeInfo @String)
+                    NE.:| [ RecordEntry "created" (mkTypeInfo @Int)
+                          , RecordEntry "updated" (mkTypeInfo @Int)
+                          ]
+                dc = DataConstructor "Foo" (Record entries) :: DataConstructor 'Haskell
+                st = SumType (mkTypeInfo @Int) [dc] [] :: SumType 'Haskell
+                SumType _ [DataConstructor _ args] _ = excludeFields ["created", "updated"] st
+                Record result = args
+            NE.length result `shouldBe` 1
+            _recLabel (NE.head result) `shouldBe` "name"
+
+        it "leaves non-record constructors unchanged" $ do
+            let dc = DataConstructor "Bar" (Normal $ NE.singleton $ mkTypeInfo @Int) :: DataConstructor 'Haskell
+                st = SumType (mkTypeInfo @Int) [dc] [] :: SumType 'Haskell
+                SumType _ [DataConstructor _ args] _ = excludeFields ["whatever"] st
+            isNormal args `shouldBe` True
+
+        it "turns constructor nullary when all fields are excluded" $ do
+            let entries = NE.singleton (RecordEntry "only" $ mkTypeInfo @Int)
+                dc = DataConstructor "Foo" (Record entries) :: DataConstructor 'Haskell
+                st = SumType (mkTypeInfo @Int) [dc] [] :: SumType 'Haskell
+                SumType _ [DataConstructor _ args] _ = excludeFields ["only"] st
+            args `shouldBe` Nullary
+
+        it "does nothing when no fields match" $ do
+            let entries = RecordEntry "name" (mkTypeInfo @String)
+                    NE.:| [RecordEntry "age" (mkTypeInfo @Int)]
+                dc = DataConstructor "Foo" (Record entries) :: DataConstructor 'Haskell
+                st = SumType (mkTypeInfo @Int) [dc] [] :: SumType 'Haskell
+                SumType _ [DataConstructor _ args] _ = excludeFields ["nonexistent"] st
+                Record result = args
+            NE.length result `shouldBe` 2
+
+        it "preserves instances" $ do
+            let entries = NE.singleton (RecordEntry "name" $ mkTypeInfo @String)
+                dc = DataConstructor "Foo" (Record entries) :: DataConstructor 'Haskell
+                st = SumType (mkTypeInfo @Int) [dc] [GenericShow, Eq] :: SumType 'Haskell
+                SumType _ _ is = excludeFields ["whatever"] st
+            length is `shouldBe` 2
 
 isNormal :: DataConstructorArgs lang -> Bool
 isNormal (Normal _) = True

--- a/test/TupleSpec.hs
+++ b/test/TupleSpec.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module TupleSpec (spec) where
+
+import           Language.PureScript.Bridge.Tuple (TupleParserState (..), isTuple, step)
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..), mkTypeInfo)
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe)
+
+spec :: Spec
+spec = do
+    describe "step (state machine transitions)" $ do
+        -- Start state transitions
+        it "Start + '(' -> OpenFound" $
+            step Start '(' `shouldBe` OpenFound
+        it "Start + any other char -> NoTuple" $
+            step Start 'a' `shouldBe` NoTuple
+        it "Start + ',' -> NoTuple" $
+            step Start ',' `shouldBe` NoTuple
+
+        -- OpenFound state transitions
+        it "OpenFound + ',' -> ColonFound" $
+            step OpenFound ',' `shouldBe` ColonFound
+        it "OpenFound + ')' -> NoTuple" $
+            step OpenFound ')' `shouldBe` NoTuple
+        it "OpenFound + 'x' -> NoTuple" $
+            step OpenFound 'x' `shouldBe` NoTuple
+
+        -- ColonFound state transitions
+        it "ColonFound + ',' -> ColonFound" $
+            step ColonFound ',' `shouldBe` ColonFound
+        it "ColonFound + ')' -> Tuple" $
+            step ColonFound ')' `shouldBe` Tuple
+        it "ColonFound + 'x' -> NoTuple" $
+            step ColonFound 'x' `shouldBe` NoTuple
+
+        -- Tuple state (absorbing)
+        it "Tuple + any char -> NoTuple" $
+            step Tuple 'x' `shouldBe` NoTuple
+        it "Tuple + ')' -> NoTuple" $
+            step Tuple ')' `shouldBe` NoTuple
+
+        -- NoTuple state (absorbing)
+        it "NoTuple + any char -> NoTuple" $
+            step NoTuple 'x' `shouldBe` NoTuple
+        it "NoTuple + '(' -> NoTuple" $
+            step NoTuple '(' `shouldBe` NoTuple
+
+    describe "isTuple" $ do
+        it "recognizes \"(,)\" as a tuple" $
+            isTuple (mkTI "(,)") `shouldBe` True
+
+        it "recognizes \"(,,)\" as a tuple" $
+            isTuple (mkTI "(,,)") `shouldBe` True
+
+        it "recognizes \"(,,,)\" as a tuple" $
+            isTuple (mkTI "(,,,)") `shouldBe` True
+
+        it "rejects \"Int\"" $
+            isTuple (mkTI "Int") `shouldBe` False
+
+        it "rejects \"Maybe\"" $
+            isTuple (mkTI "Maybe") `shouldBe` False
+
+        it "rejects empty string" $
+            isTuple (mkTI "") `shouldBe` False
+
+        it "rejects \"(\"" $
+            isTuple (mkTI "(") `shouldBe` False
+
+        it "rejects \"(,\"" $
+            isTuple (mkTI "(,") `shouldBe` False
+
+        it "rejects \"()\" (unit, not a tuple)" $
+            isTuple (mkTI "()") `shouldBe` False
+
+        it "rejects \"(,,\" (no closing paren)" $
+            isTuple (mkTI "(,,") `shouldBe` False
+
+  where
+    mkTI name = TypeInfo "" "" name []

--- a/test/TypeInfoSpec.hs
+++ b/test/TypeInfoSpec.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE DataKinds         #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeApplications  #-}
+
+module TypeInfoSpec (spec) where
+
+import qualified Data.Text as T
+import           Language.PureScript.Bridge.TypeInfo (TypeInfo (..),
+                                                      flattenTypeInfo,
+                                                      mkTypeInfo)
+import           Test.Hspec (Spec, describe, it)
+import           Test.Hspec.Expectations.Pretty (shouldBe, shouldSatisfy)
+
+spec :: Spec
+spec = do
+    describe "mkTypeInfo" $ do
+        it "creates TypeInfo for Int" $ do
+            let ti = mkTypeInfo @Int
+            _typeName ti `shouldBe` "Int"
+            _typeParameters ti `shouldBe` []
+
+        it "creates TypeInfo for Bool" $ do
+            let ti = mkTypeInfo @Bool
+            _typeName ti `shouldBe` "Bool"
+            _typeParameters ti `shouldBe` []
+
+        it "creates TypeInfo for Maybe Int (parameterized type)" $ do
+            let ti = mkTypeInfo @(Maybe Int)
+            _typeName ti `shouldBe` "Maybe"
+            length (_typeParameters ti) `shouldBe` 1
+            _typeName (head $ _typeParameters ti) `shouldBe` "Int"
+
+        it "creates TypeInfo for Either String Int (two type parameters)" $ do
+            let ti = mkTypeInfo @(Either String Int)
+            _typeName ti `shouldBe` "Either"
+            length (_typeParameters ti) `shouldBe` 2
+            _typeName (last $ _typeParameters ti) `shouldBe` "Int"
+
+        it "creates TypeInfo for nested Maybe (Either String Int)" $ do
+            let ti = mkTypeInfo @(Maybe (Either String Int))
+            _typeName ti `shouldBe` "Maybe"
+            length (_typeParameters ti) `shouldBe` 1
+            let inner = head $ _typeParameters ti
+            _typeName inner `shouldBe` "Either"
+            length (_typeParameters inner) `shouldBe` 2
+
+        it "populates _typeModule" $ do
+            let ti = mkTypeInfo @Int
+            _typeModule ti `shouldSatisfy` (not . T.null)
+
+        it "populates _typePackage" $ do
+            let ti = mkTypeInfo @Int
+            _typePackage ti `shouldSatisfy` (not . T.null)
+
+    describe "flattenTypeInfo" $ do
+        it "flattens a simple type to a singleton list" $ do
+            let ti = mkTypeInfo @Int
+            flattenTypeInfo ti `shouldBe` [ti]
+
+        it "flattens Maybe Int to [Maybe, Int]" $ do
+            let ti = mkTypeInfo @(Maybe Int)
+                flat = flattenTypeInfo ti
+            length flat `shouldBe` 2
+            _typeName (head flat) `shouldBe` "Maybe"
+            _typeName (flat !! 1) `shouldBe` "Int"
+
+        it "flattens nested types recursively" $ do
+            let ti = mkTypeInfo @(Maybe (Either String Int))
+                flat = flattenTypeInfo ti
+            -- At minimum: Maybe, Either, [something for String], Int
+            length flat `shouldSatisfy` (>= 4)
+            _typeName (head flat) `shouldBe` "Maybe"
+
+        it "flattens type with no parameters to singleton" $ do
+            let ti = mkTypeInfo @Bool
+            flattenTypeInfo ti `shouldBe` [ti]
+
+    describe "HasHaskType" $ do
+        it "haskType lens on HaskellType is identity (structural test)" $ do
+            -- The haskType lens for HaskellType is just id
+            -- We verify TypeInfo equality works correctly
+            let ti = mkTypeInfo @Int
+            ti `shouldBe` ti
+            let ti2 = mkTypeInfo @(Maybe Int)
+            ti2 `shouldBe` ti2
+            ti `shouldSatisfy` (/= ti2)


### PR DESCRIPTION
This PR adds support for generating `Foldable` and `Traversable` instances in PureScript, brings in a proper test suite, and fixes a few bugs that were found along the way.

The main addition is `Foldable` and `Traversable` deriving, which works the same way as the existing `Functor` support. There are new `foldable` and `traversable` helper functions to opt in to instance generation, and the printer knows how to emit `derive instance` declarations for both. The necessary import lines for `Data.Foldable` and `Data.Traversable` are also wired up.

While working on this I also added a comprehensive test suite covering the builder, printer, sum types, primitives, PS types, tuples, and type info modules. Writing those tests turned up a few issues that are also fixed here: a duplicate `typeToEncode` clause for tuples, a `Debug.Trace` import that was left in, an infinite loop in `instanceToImportLines` for `Prisms`, and a partial function call in `typeParams` that would crash on empty type names.

---

Can you please enable issues on this repo? and set peterbecich:merge-iohk-3 as peterbecich:main?